### PR TITLE
A new implementation for \includepaper

### DIFF
--- a/langsci-unified.cbx
+++ b/langsci-unified.cbx
@@ -321,6 +321,18 @@
    \printtext[bibhyperref]{\bibopenparen\printnames{labelname}\addspace\printfield{year}}}
   {\multicitedelim}
   {\printtext[bibhyperref]{\usebibmacro{postnote}\addspace[this volume]\bibcloseparen}}
+  
+% A cite command to produce the full reference in the footer of the landing page of 
+% a paper in an edited volume
+
+\DeclareCiteCommand{\fullciteFooter}
+  {\defcounter{maxnames}{\blx@maxbibnames}%
+    \usebibmacro{prenote}}
+  {\usedriver
+     {\DeclareNameAlias{sortname}{default}}
+     {\thefield{entrytype}}}
+  {\multicitedelim}
+  {\usebibmacro{postnote}}
 
 \DeclareMultiCiteCommand{\cites}{\cite}{\setunit{\multicitedelim}}
 \DeclareMultiCiteCommand{\parencites}[\mkbibparens]{\parencite}{\setunit{\multicitedelim}}

--- a/langscibook.cls
+++ b/langscibook.cls
@@ -255,6 +255,13 @@
 
 \ProcessKeyvalOptions{langscibook}
 
+% \newcommand{\lsOutputLong}{long}
+\newcommand{\lsOutputBook}{book}             % standard book
+\newcommand{\lsOutputPaper}{paper}            % paper in edited volume
+\newcommand{\lsOutputGuidelines}{guidelines}  % guidelines
+\newcommand{\lsOutputCoverBODsc}{coverbodsc}      % cover with BoD measurements
+\newcommand{\lsOutputCoverBODhc}{coverbodhc}      % cover with BoD measurements
+\newcommand{\lsOutputCoverCS}{covercreatespace} % cover with CreateSpace measurements
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %     Class
@@ -269,9 +276,8 @@
   index=totoc,
   headings=optiontohead,
 % %   headings=normal,
-  \iflsCollection
-    chapterprefix=true,
-  \fi
+  \iflsCollection chapterprefix=true,\else
+    \ifx\lsOutput\lsOutputPaper  chapterprefix=true,\else \fi\fi
   %draft=yes,
   %appendixprefix
   ]{scrbook}
@@ -441,27 +447,19 @@
 \fi
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %      Output types
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-% \newcommand{\lsOutputLong}{long}
-\newcommand{\lsOutputBook}{book}             % standard book
-\newcommand{\lsOutputPaper}{paper}            % paper in edited volume
-\newcommand{\lsOutputGuidelines}{guidelines}  % guidelines
-\newcommand{\lsOutputCoverBODsc}{coverbodsc}      % cover with BoD measurements
-\newcommand{\lsOutputCoverBODhc}{coverbodhc}      % cover with BoD measurements
-\newcommand{\lsOutputCoverCS}{covercreatespace} % cover with CreateSpace measurements
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 %% Output types are defined with \newcommand above so they can be used with geometry.
 
-\AtBeginDocument{
+\ifx\lsOutput\lsOutputPaper
+% A paper differs in title generation from the other
+% output types, and it needs more input to produce
+% its title. This is why \maketitle for output==paper
+% is deffered until later. See the call to \includepaper@body.
+\else % only if output!=paper
+\AtBeginDocument{%
 \iflsMinimal\renewcommand{\maketitle}{You are using the minimal mode.}\else % The minimal mode skips cover generation
-\ifx\lsOutput\lsOutputPaper       % only if output==paper
-  \usepackage{chngcntr}
-  \counterwithout{figure}{chapter}
-  \counterwithout{table}{chapter}
-  \includepaper@body
-\else                 % only if output!=paper
 \renewcommand{\maketitle}{
 \begin{titlepage}
  \thispagestyle{empty}
@@ -566,7 +564,6 @@
 
 } %% \maketitle
 \fi
-\fi
 %% for those who like the example in numbered example sentences to be typeset in italics
 %% this is possible for a complete series only.
 \ifx\lsSeries\sidl
@@ -587,8 +584,8 @@
 \fi
 
 
-
 } %% \AtBeginDocument
+\fi %% end \else of if output == paper
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1880,6 +1877,7 @@ width=.8\textwidth
         \fi% If the paper is not within \includeonly, don't do anything.
 	\end{refsection}
 \egroup}
+\fi
 
 \newcommand{\lsCollectionPaperHeaderTitle}{%
   \renewcommand{\newlineCover}{}
@@ -1894,12 +1892,17 @@ width=.8\textwidth
   \onlyAuthor\@author}}
 
 \newcommand{\includepaper@body}{
-    \RenewDocumentCommand{\title}{O{##2} m O{##2}}{\newcommand{\titleToHead}{##1}\newcommand{\titleTemp}{##2}\newcommand{\titleToToC}{##3}}
+    \RenewDocumentCommand{\title}{O{##2} m O{##2}}{
+      \newcommand{\titleToHead}{##1}
+      \newcommand{\titleTemp}{##2}
+      \newcommand{\titleToToC}{##3}
+    }
     \renewcommand{\author}[1]{\renewcommand{\@author}{##1}}
     \RedeclareSectionCommand[afterskip=1.15\baselineskip plus .1\baselineskip minus .167\baselineskip]{chapter}
     \renewcommand*{\thesection}{\arabic{section}}
     \renewcommand{\maketitle}{
-      \chapter[tocentry={\titleToToC\newline{\normalfont \@author}}]{\titleTemp}
+      \chapter[tocentry={\titleToToC~\newline{\normalfont \@author}}]{\titleTemp}
+%         \chapter{\@title}
       \global\edef\lsCollectionPaperFirstPage{\thepage} % for citation in footer
       \onlyAuthor
       \renewcommand{\newlineCover}{}
@@ -1920,7 +1923,6 @@ width=.8\textwidth
   \lehead{\lsCollectionPaperHeaderAuthor}
   \rohead{\lsCollectionPaperHeaderTitle}
  }
-\fi
 
 \newcommand{\onlyAuthor}{%    % collection paper
   \renewcommand{\and}{, }%
@@ -1933,50 +1935,7 @@ width=.8\textwidth
   \renewcommand{\lastand}{\newline\newline}
   \renewcommand{\affiliation}[1]{\\[0.5ex]{\normalsize ##1}}}
 
-% \newcommand{\lsCollectionPaperTOC}{{%
-%   \iflsCollectionChapter%
-%     \protect\numberline{\thechapter}\fi
-%     \@title\ \newline{\normalfont\@author}}} % space between \@title and \newline is needed for bookmarks
-
-% \newcommand{\lsCollectionPaperTitle}{{%
-%   \renewcommand{\newlineTOC}{}
-%   \renewcommand{\newlineCover}{\\}
-%   \renewcommand{\chapterheadstartvskip}{}
-%   {\LARGE \noindent \hspace*{-.7cm} \localizedchaptestring~\thechapter}\\ %there must be a better way to undo this length than a hard value
-%   \bigskip
-%   \@title}}
-
 \newcommand{\lsCollectionPaperFooterTitle}{\titleTemp}
-
-\newcommand{\lsCollectionPaperFrontmatterMode}{% %%% Sometimes, chapters like prefaces appear in edited volumes that need special treatment in their headers and TOC
-  \renewcommand{\lsCollectionPaperTitle}{{%
-  \renewcommand{\newlineTOC}{}
-  \renewcommand{\newlineCover}{\\}
-  \\[-1\baselineskip]
-  \noindent{\LARGE ~}\\
-  \bigskip
-  \noindent\@title}}
-
-  \renewcommand{\lsCollectionPaperTOC}{{%
-  \iflsCollectionChapter%
-    \protect\numberline{~}\fi
-  \@title\ \newline{\normalfont\@author}}}
-}
-
-\newcommand{\lsCollectionPaperMainmatterMode}{% %%% This resets the changes done by FrontmatterMode
-  \renewcommand{\lsCollectionPaperTitle}{{%
-  \renewcommand{\newlineTOC}{}
-  \renewcommand{\newlineCover}{\\}
-  \\[-1\baselineskip]
-% \vspace*{-2\baselineskip}
-  \noindent{\LARGE Chapter \thechapter}\\
-  \bigskip
-  \@title}}
-
-  \renewcommand{\lsCollectionPaperTOC}{{%
-  \iflsCollectionChapter%
-    \protect\numberline{\thechapter}\fi
-  \@title\ \newline{\normalfont\@author}}}}
 
 \newcommand{\lsCollectionPaperAuthor}{{%
   \renewcommand{\newlineTOC}{}
@@ -1999,12 +1958,15 @@ width=.8\textwidth
 
 \providecommand\shorttitlerunninghead[1]{\rohead{\thechapter\hspace{.5em} #1}}
 
-\providecommand{\markuptitle}[2]{
-  \title{\texorpdfstring{#1}{#2}}
-  \shorttitlerunninghead{#2}
-  \renewcommand{\lsChapterFooterSize}{\scriptsize}
-  \renewcommand{\lsCollectionPaperFooterTitle}{Add\noexpand\texttt{\textbackslash renewcommand\{\textbackslash lsCollectionPaperFooterTitle\}\{A new theory of \textbackslash noexpand\textbackslash textit\{This\} and \textbackslash noexpand\textbackslash textit\{that\}\}} to preamble}
-}
+% In output==paper, the title is generated with the info
+% collected by the commands above.
+\ifx\lsOutput\lsOutputPaper
+  \usepackage{chngcntr}
+  \counterwithout{figure}{chapter}
+  \counterwithout{table}{chapter}
+  \includepaper@body
+\else % only if output!=paper
+\fi
 
 
 %writeout page numbers for separation of chapters
@@ -2022,9 +1984,6 @@ width=.8\textwidth
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %    Localisation
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
-
 
 \ifx\lsBookLanguage\lsBookLanguageFrench
   \renewcommand{\chapref}[1]{Chapitre~\ref{#1}}

--- a/langscibook.cls
+++ b/langscibook.cls
@@ -1884,7 +1884,7 @@ width=.8\textwidth
   \renewcommand{\newlineTOC}{}
   \iflsCollectionChapter%
     \thechapter\hspace{0.5em}\fi
-  \titleTemp}
+  \titleToHead}
   
 \newcommand{\lsCollectionPaperHeaderAuthor}{{%
   \renewcommand{\newlineCover}{}%
@@ -1902,12 +1902,10 @@ width=.8\textwidth
     \renewcommand*{\thesection}{\arabic{section}}
     \renewcommand{\maketitle}{
       \chapter[tocentry={\titleToToC~\newline{\normalfont \@author}}]{\titleTemp}
-%         \chapter{\@title}
       \global\edef\lsCollectionPaperFirstPage{\thepage} % for citation in footer
       \onlyAuthor
       \renewcommand{\newlineCover}{}
       \renewcommand{\newlineTOC}{\\}
-%     \addcontentsline{toc}{chapter}{\lsCollectionPaperTOC}%
       \ifoot[\lsCollectionPaperCitation]{\iflsDraft Draft of \today, \currenttime \fi}
       \lsCollectionPaperAuthor%
       \vspace*{\baselineskip}%

--- a/langscibook.cls
+++ b/langscibook.cls
@@ -1883,7 +1883,10 @@ width=.8\textwidth
   \renewcommand{\newlineCover}{}
   \renewcommand{\newlineTOC}{}
   \iflsCollectionChapter%
-    \thechapter\hspace{0.5em}\fi
+    \ifnum\thechapter>0% Do not send chapter number "0" (fronmatter) to head.
+      \thechapter\hspace{0.5em}
+    \fi
+  \fi
   \titleToHead}
   
 \newcommand{\lsCollectionPaperHeaderAuthor}{{%

--- a/langscibook.cls
+++ b/langscibook.cls
@@ -1898,24 +1898,36 @@ width=.8\textwidth
       \newcommand{\titleToToC}{##3}
     }
     \renewcommand{\author}[1]{\renewcommand{\@author}{##1}}
-    \RedeclareSectionCommand[afterskip=1.15\baselineskip plus .1\baselineskip minus .167\baselineskip]{chapter}
     \renewcommand*{\thesection}{\arabic{section}}
+    \RedeclareSectionCommand
+      [afterskip=1.15\baselineskip plus .1\baselineskip minus .167\baselineskip,
+       beforeskip=0pt
+      ]{chapter}
     \renewcommand{\maketitle}{
+      % With \setchapterpreamble from scrbook, we ensure that the author(s),
+      % their affiliation, the abstract, etc., are part of the \chapter block.
+      \setchapterpreamble[u]{
+        \onlyAuthor
+        \lsCollectionPaperAuthor%
+        \vspace{\baselineskip}
+        \ifx\@epigram\empty%
+          \else {\epigraph{\@epigram\\[-5ex]}{\@epigramsource}%
+              \epigram{}\epigramsource{}}%
+        \fi%
+        \begin{quote}
+          \small\lsCollectionPaperAbstract
+        \end{quote}
+        \vspace{\baselineskip}
+      }
       \chapter[tocentry={\titleToToC~\newline{\normalfont \@author}}]{\titleTemp}
       \global\edef\lsCollectionPaperFirstPage{\thepage} % for citation in footer
-      \onlyAuthor
       \renewcommand{\newlineCover}{}
       \renewcommand{\newlineTOC}{\\}
       \ifoot[\lsCollectionPaperCitation]{\iflsDraft Draft of \today, \currenttime \fi}
-      \lsCollectionPaperAuthor%
-      \vspace*{\baselineskip}%
-      \ifx\@epigram\empty%
-        \else {\epigraph{\@epigram\\[-5ex]}{\@epigramsource}%
-            \epigram{}\epigramsource{}}%
-      \fi%
-      \begin{quote}
-        \small\lsCollectionPaperAbstract
-      \end{quote}
+      % The following ensure that a chapter is treated as a heading, which
+      % controls page break penalties and indentation following the heading.
+      \@afterindentfalse
+      \@afterheading
     }
   \ohead{}
   \lehead{\lsCollectionPaperHeaderAuthor}

--- a/langscibook.cls
+++ b/langscibook.cls
@@ -456,7 +456,7 @@
 % A paper differs in title generation from the other
 % output types, and it needs more input to produce
 % its title. This is why \maketitle for output==paper
-% is deffered until later. See the call to \includepaper@body.
+% is deferred until later. See the call to \includepaper@body.
 \else % only if output!=paper
 \AtBeginDocument{%
 \iflsMinimal\renewcommand{\maketitle}{You are using the minimal mode.}\else % The minimal mode skips cover generation

--- a/langscibook.cls
+++ b/langscibook.cls
@@ -268,7 +268,10 @@
   toc=bibliography,
   index=totoc,
   headings=optiontohead,
-  %chapterprefix=true,
+% %   headings=normal,
+  \iflsCollection
+    chapterprefix=true,
+  \fi
   %draft=yes,
   %appendixprefix
   ]{scrbook}
@@ -457,7 +460,7 @@
   \usepackage{chngcntr}
   \counterwithout{figure}{chapter}
   \counterwithout{table}{chapter}
-  \lsPaper
+  \includepaper@body
 \else                 % only if output!=paper
 \renewcommand{\maketitle}{
 \begin{titlepage}
@@ -1812,15 +1815,15 @@ width=.8\textwidth
 	\fi
 
 
-\AtBeginDocument{	% for the citation in the footer
+\AtBeginDocument{% for the citation in the footer
 	\onlyAuthor
 	\renewcommand{\newlineCover}{}
 	\renewcommand{\newlineSpine}{}
-	\edef\lsCollectionTitle{\@title\ifx\@subtitle\empty\else{: \@subtitle}\fi}		% \edef immediately expands \@title
+	\edef\lsCollectionTitle{\@title\ifx\@subtitle\empty\else{: \@subtitle}\fi}% \edef immediately expands \@title
 	\edef\lsCollectionEditor{\@author}
 	\addbibresource{collection_tmp.bib}
 	\if@partsw\AfterEndDocument{\typeout{langscibook Warning: You are in includeonly mode.}\typeout{The bibliographical information for the chapters in this volume have not been updated}}\else% Check for \includeonly mode
-	\newwrite\tempfile						% open temporary bib file
+	\newwrite\tempfile% open temporary bib file
 	\immediate\openout\tempfile=collection_tmp.bib
 	\fi
 }
@@ -1839,45 +1842,25 @@ width=.8\textwidth
     pagenumberbox={\csname @gobble\endcsname},
     raggedentrytext=true,
     linefill={\hfill}
-  ]{tocline}{part} 
-
+  ]{tocline}{part}
+  
 \usepackage{chngcntr}
 \counterwithout{figure}{chapter}
 \counterwithout{table}{chapter}
 
-%% Modified code from:
-%% http://pastcounts.wordpress.com/2010/12/20/how-to-construct-a-collection-of-articles-with-latex/
-\newenvironment{collectionpaper}{
+\NewDocumentCommand{\includepaper}{m}{
+\bgroup
 	\renewcommand{\documentclass}[2][]{}%
 	\renewcommand{\usepackage}[2][]{}%
-	\renewenvironment{document}{\begingroup}{\endgroup}%
-
-	\renewcommand{\title}[1]{\renewcommand{\@title}{##1}}
-	\renewcommand{\author}[1]{\renewcommand{\@author}{##1}}
-	%\renewcommand{\thanks}[1]{\symbolfootnote[1]{##1}}
-	\lsPaper
-	}
-	{}
-
-\newcommand{\includepaper}[1]{
-	\begin{collectionpaper}
+	\renewenvironment{document}{\begingroup}{\endgroup}
+	\includepaper@body
 	\begin{refsection}
-
-	\DeclareCiteCommand{\fullciteFooter}
-		{\defcounter{maxnames}{\blx@maxbibnames}%
-		  \usebibmacro{prenote}}
-		{\usedriver
-		   {\DeclareNameAlias{sortname}{default}}
-		   {\thefield{entrytype}}}
-		{\multicitedelim}
-		{\usebibmacro{postnote}}
 	\renewcommand{\lsCollectionPaperCitationText}{\fullciteFooter{#1footer}}
-
 	\include{#1}%
-        \if@partsw\relax\else% This switch controls whether the included chapter is in the range of \includeonly. It's from source2e.
-          \addtocounter{page}{-1}
-	  \edef\lsCollectionPaperLastPage{\thepage}	% \lsCollectionPaperFirstPage is defined in \lsPaper
-          \addtocounter{page}{1}
+    \if@partsw\relax\else% This switch controls whether the included chapter is in the range of \includeonly. It's from source2e.
+    \addtocounter{page}{-1}
+    \edef\lsCollectionPaperLastPage{\thepage}	% \lsCollectionPaperFirstPage is defined in \includepaper@body
+    \addtocounter{page}{1}
 
 	%%% for citation in footer
 	%% preprocessing of author/editor names
@@ -1892,11 +1875,51 @@ width=.8\textwidth
 
 	%% write bib entry to file
 	%% FIXME: the publisher field needs a final period, since this is not provided by \fullciteFooter together with DOIs.
-	\immediate\write\tempfile{@incollection{#1,author={\authorTemp},title={{\lsCollectionPaperFooterTitle}},booktitle={{\lsCollectionTitle}},editor={\editorTemp},publisher={Language Science Press.},Address={Berlin},year={\lsYear},pages={\lsCollectionPaperFirstPage --\lsCollectionPaperLastPage},doi={\lsChapterDOI},keywords={withinvolume}}}
-	\immediate\write\tempfile{@incollection{#1footer,author={\authorTemp},title={{\lsCollectionPaperFooterTitle}},booktitle={{\lsCollectionTitle}},editor={\editorTemp},publisher={Language Science Press.},Address={Berlin},year={\lsYear},pages={\lsCollectionPaperFirstPage --\lsCollectionPaperLastPage},doi={\lsChapterDOI},options={dataonly=true}}}
+	\immediate\write\tempfile{@incollection{#1,author={\authorTemp},title={{\expandonce{\titleTemp}}},booktitle={{\expandonce{\lsCollectionTitle}}},editor={\editorTemp},publisher={Language Science Press.},Address={Berlin},year={\lsYear},pages={\lsCollectionPaperFirstPage --\lsCollectionPaperLastPage},doi={\lsChapterDOI},keywords={withinvolume}}}
+	\immediate\write\tempfile{@incollection{#1footer,author={\authorTemp},title={{\expandonce{\titleTemp}}},booktitle={{\expandonce{\lsCollectionTitle}}},editor={\editorTemp},publisher={Language Science Press.},Address={Berlin},year={\lsYear},pages={\lsCollectionPaperFirstPage --\lsCollectionPaperLastPage},doi={\lsChapterDOI},options={dataonly=true}}}
         \fi% If the paper is not within \includeonly, don't do anything.
 	\end{refsection}
-	\end{collectionpaper}}
+\egroup}
+
+\newcommand{\lsCollectionPaperHeaderTitle}{%
+  \renewcommand{\newlineCover}{}
+  \renewcommand{\newlineTOC}{}
+  \iflsCollectionChapter%
+    \thechapter\hspace{0.5em}\fi
+  \titleTemp}
+  
+\newcommand{\lsCollectionPaperHeaderAuthor}{{%
+  \renewcommand{\newlineCover}{}%
+  \renewcommand{\newlineTOC}{}%
+  \onlyAuthor\@author}}
+
+\newcommand{\includepaper@body}{
+    \RenewDocumentCommand{\title}{O{##2} m O{##2}}{\newcommand{\titleToHead}{##1}\newcommand{\titleTemp}{##2}\newcommand{\titleToToC}{##3}}
+    \renewcommand{\author}[1]{\renewcommand{\@author}{##1}}
+    \RedeclareSectionCommand[afterskip=1.15\baselineskip plus .1\baselineskip minus .167\baselineskip]{chapter}
+    \renewcommand*{\thesection}{\arabic{section}}
+    \renewcommand{\maketitle}{
+      \chapter[tocentry={\titleToToC\newline{\normalfont \@author}}]{\titleTemp}
+      \global\edef\lsCollectionPaperFirstPage{\thepage} % for citation in footer
+      \onlyAuthor
+      \renewcommand{\newlineCover}{}
+      \renewcommand{\newlineTOC}{\\}
+%     \addcontentsline{toc}{chapter}{\lsCollectionPaperTOC}%
+      \ifoot[\lsCollectionPaperCitation]{\iflsDraft Draft of \today, \currenttime \fi}
+      \lsCollectionPaperAuthor%
+      \vspace*{\baselineskip}%
+      \ifx\@epigram\empty%
+        \else {\epigraph{\@epigram\\[-5ex]}{\@epigramsource}%
+            \epigram{}\epigramsource{}}%
+      \fi%
+      \begin{quote}
+        \small\lsCollectionPaperAbstract
+      \end{quote}
+    }
+  \ohead{}
+  \lehead{\lsCollectionPaperHeaderAuthor}
+  \rohead{\lsCollectionPaperHeaderTitle}
+ }
 \fi
 
 \newcommand{\onlyAuthor}{%    % collection paper
@@ -1910,33 +1933,20 @@ width=.8\textwidth
   \renewcommand{\lastand}{\newline\newline}
   \renewcommand{\affiliation}[1]{\\[0.5ex]{\normalsize ##1}}}
 
-\newcommand{\lsCollectionPaperHeaderAuthor}{{%
-  \renewcommand{\newlineCover}{}%
-  \renewcommand{\newlineTOC}{}%
-  \onlyAuthor\@author}}
+% \newcommand{\lsCollectionPaperTOC}{{%
+%   \iflsCollectionChapter%
+%     \protect\numberline{\thechapter}\fi
+%     \@title\ \newline{\normalfont\@author}}} % space between \@title and \newline is needed for bookmarks
 
-\newcommand{\lsCollectionPaperHeaderTitle}{%
-  \renewcommand{\newlineCover}{}
-  \renewcommand{\newlineTOC}{}
-  \iflsCollectionChapter%
-    \thechapter\hspace{0.5em}\fi
-  \@title}
+% \newcommand{\lsCollectionPaperTitle}{{%
+%   \renewcommand{\newlineTOC}{}
+%   \renewcommand{\newlineCover}{\\}
+%   \renewcommand{\chapterheadstartvskip}{}
+%   {\LARGE \noindent \hspace*{-.7cm} \localizedchaptestring~\thechapter}\\ %there must be a better way to undo this length than a hard value
+%   \bigskip
+%   \@title}}
 
-\newcommand{\lsCollectionPaperTOC}{{%
-  \iflsCollectionChapter%
-    \protect\numberline{\thechapter}\fi
-    \@title\ \newline{\normalfont\@author}}} % space between \@title and \newline is needed for bookmarks
-
-\newcommand{\localizedchaptestring}{Chapter}
-\newcommand{\lsCollectionPaperTitle}{{%
-  \renewcommand{\newlineTOC}{}
-  \renewcommand{\newlineCover}{\\}
-  \renewcommand{\chapterheadstartvskip}{}
-  {\LARGE \noindent \hspace*{-.7cm} \localizedchaptestring~\thechapter}\\ %there must be a better way to undo this length than a hard value
-  \bigskip
-  \@title}}
-
-\newcommand{\lsCollectionPaperFooterTitle}{\@title}
+\newcommand{\lsCollectionPaperFooterTitle}{\titleTemp}
 
 \newcommand{\lsCollectionPaperFrontmatterMode}{% %%% Sometimes, chapters like prefaces appear in edited volumes that need special treatment in their headers and TOC
   \renewcommand{\lsCollectionPaperTitle}{{%
@@ -1986,39 +1996,6 @@ width=.8\textwidth
 
 \newcommand{\papernote}[1]{
   \renewcommand{\lsCollectionPaperCitation}{#1}}
-
-\newcommand{\lsPaper}{
-  \renewcommand{\maketitle}{
-    \refstepcounter{chapter}
-    \addchap*{\lsCollectionPaperTitle}
-    \global\edef\lsCollectionPaperFirstPage{\thepage} % for citation in footer
-    \onlyAuthor
-    \renewcommand{\newlineCover}{}
-    \renewcommand{\newlineTOC}{\\}
-    \addcontentsline{toc}{chapter}{\lsCollectionPaperTOC}%
-    \ifoot[\lsCollectionPaperCitation]{\iflsDraft Draft of \today, \currenttime \fi}
-    \vspace*{-2ex}
-    \lsCollectionPaperAuthor%
-    \vspace*{\baselineskip}%
-    \ifx\@epigram\empty%
-      \else {\epigraph{\@epigram\\[-5ex]}{\@epigramsource}%
-          \epigram{}\epigramsource{}}%
-    \fi%
-    \begin{quote}
-    \small\lsCollectionPaperAbstract
-    \end{quote}
-  }
-
-  \renewcommand*{\thesection}{\arabic{section}}
-  \setcounter{section}{0}
-  \setcounter{footnote}{0}
-  \setcounter{figure}{0}
-  \setcounter{table}{0}
-  \setcounter{equation}{0}  % for examples
-  \ohead{}
-  \lehead{\lsCollectionPaperHeaderAuthor}
-  \rohead{\lsCollectionPaperHeaderTitle}
-}
 
 \providecommand\shorttitlerunninghead[1]{\rohead{\thechapter\hspace{.5em} #1}}
 

--- a/langscibook.cls
+++ b/langscibook.cls
@@ -794,6 +794,17 @@
       ]
       {tocline}
       {section,subsection,subsubsection,paragraph,subparagraph}
+    
+    % In collected volumes, adjust the spacing for unnumbered chapters
+    \iflsCollection
+      \renewcommand{\addtocentrydefault}[3]{%
+        \ifstr{#2}{}{%
+          \addcontentsline{toc}{#1}{\protect\numberline{~}#3}%
+        }{%
+          \addcontentsline{toc}{#1}{\protect\numberline{#2}#3}%
+          }%
+      }%
+    \fi
 
     \frenchspacing	%see https://en.wikipedia.org/wiki/Sentence_spacing#Typography
     \usepackage[final]{microtype}
@@ -1883,8 +1894,8 @@ width=.8\textwidth
   \renewcommand{\newlineCover}{}
   \renewcommand{\newlineTOC}{}
   \iflsCollectionChapter%
-    \ifnum\thechapter>0% Do not send chapter number "0" (fronmatter) to head.
-      \thechapter\hspace{0.5em}
+    \if@mainmatter%Only send the chapter num to head if in mainmatter.
+      \thechapter\hspace{0.5em}\else
     \fi
   \fi
   \titleToHead}

--- a/tests/collection-main.tex
+++ b/tests/collection-main.tex
@@ -4,11 +4,12 @@
   % ,undecapitalize
   ,biblatex
   ,multiauthors
-  ,nobabel
-  ,booklanguage=french
+%   ,nobabel
+%   ,booklanguage=ngerman
   ]{../langscibook}
 
-\usepackage[english]{babel}
+% \usepackage[english]{babel}
+\usepackage{kantlipsum}
 % \usepackage{./langsci-basic}
 \usepackage{langsci-tbls}
 \usepackage{langsci-optional}
@@ -43,10 +44,12 @@
 \begin{document}
 \maketitle
 \tableofcontents
+\mainmatter
 
 \part{Phonology}
 \renewcommand{\lsChapterFooterSize}{\footnotesize}
 \includepaper{collection-tests/01}
+% \includepaper{collection-tests/01}
 
 \part{Syntaxx}
 \part{Syntax}

--- a/tests/collection-tests/01.tex
+++ b/tests/collection-tests/01.tex
@@ -1,20 +1,54 @@
 \documentclass[output=minimal]{../../langscibook}
-\title{Change Title in chapters/01.tex}
+\title[]{Distinct featural classes of \textit{anaphor} in an enriched person system}
 \author{%
- Jane Meier  \affiliation{University of Eden}
+ Sandhya Sundaresan  \affiliation{Universität Leipzig}
 }
 
 % \epigram{Change epigram in chapters/01.tex or remove it there }
 
-\abstract{Change the  abstract in chapters/01.tex
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean nec fermentum risus, vehicula gravida magna. Sed dapibus venenatis scelerisque. In elementum dui bibendum, ultricies sem ac, placerat odio. Vivamus rutrum lacus eros, interdum scelerisque est euismod eget. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
-}
+\abstract{This paper tackles the fundamental question of what an
+  anaphor actually is -- and asks whether the label ``anaphor'' even
+  carves out a homogenous class of element in grammar.  While most
+  theories are in agreement that an anaphor is an element that is
+  referentially deficient in some way, the question of how this might
+  be encoded in terms of deficiency for syntactic features remains
+  largely unresolved. The conventional wisdom is that anaphors lack
+  some or more φ-features. A less mainstream view proposes that
+  anaphors are deficient for features that directly target
+  reference. Here, I present different types of empirical evidence
+  from a range of languages to argue that neither approach gets the
+  full range of facts quite right. The role of \textsc{person}, in particular,
+  seems to be privileged. Some anaphors wear the empirical properties
+  of a \textsc{person}-defective nominal; yet others, however, are sensitive
+  to \textsc{person}-restrictions in a way that indicates that they are
+  inherently specified for \textsc{person}. Orthogonal to these are anaphors
+  whose distribution seems to be regulated, not by φ-features at
+  all, but by perspective-sensitivity. Anaphors must, then, not be
+  created equal, but be distinguished along featural classes. I
+  delineate what this looks like against a binary feature system for
+  \textsc{person} enriched with a privative [\textsc{sentience}] feature. The
+  current model is shown to make accurate empirical predictions for
+  anaphors that are \emph{in}sensitive to \textsc{person}-asymmetries for the
+  PCC, animacy effects for anaphoric agreement, and instances of
+  non-matching for \textsc{num} and \textsc{person}.}
 
 \begin{document}
 \maketitle
 
+
 \section{Introduction}
-Phasellus maximus erat ligula, accumsan rutrum augue facilisis in. Proin sit amet pharetra nunc, sed maximus erat. Duis egestas mi eget purus venenatis vulputate vel quis nunc. Nullam volutpat facilisis tortor, vitae semper ligula dapibus sit amet. Suspendisse fringilla, quam sed laoreet maximus, ex ex placerat ipsum, porta ultrices mi risus et lectus. Maecenas vitae mauris condimentum justo fringilla sollicitudin. Fusce nec interdum ante. Curabitur tempus dui et orci convallis molestie \citep{Chomsky1957}.
+Phasellus maximus erat ligula, accumsan rutrum augue facilisis in. Proin sit amet pharetra nunc, sed maximus erat. Duis egestas mi eget purus venenatis vulputate vel quis nunc. Nullam volutpat facilisis tortor, vitae semper ligula dapibus sit amet. Suspendisse fringilla, quam sed laoreet maximus, ex ex placerat ipsum, porta ultrices mi risus et lectus. Maecenas vitae mauris condimentum justo fringilla sollicitudin. Fusce nec interdum ante. Curabitur tempus dui et orci convallis molestie \citep{Chomsky1957}. 
+
+\kant[1-4]
+
+\begin{table}
+\caption{A table}
+\end{table}
+
+
+\ea An example \z
+
+\section{Another section}
 
 \section*{Abbreviations}
 \begin{tabularx}{.45\textwidth}{lX}

--- a/tests/collection-tests/02.tex
+++ b/tests/collection-tests/02.tex
@@ -1,6 +1,6 @@
 \documentclass[output=paper]{langsci/langscibook} 
-\author{Change author in chapters/02.tex}
-\markuptitle{All about \textsc{capitals}}{All about CAPITALS}
+\author{Changé author in chapters/02.tex}
+\title{All about \textsc{capitals}}
 % \chapterDOI{} %will be filled in at production
  
 \abstract{Change the  abstract in chapters/02.tex \lipsum[4]}

--- a/tests/langscibook
+++ b/tests/langscibook
@@ -1,1 +1,0 @@
-../langscibook


### PR DESCRIPTION
This collection of commits improve our `\includepaper` command, used in collected volumes and the `paper` option of `langscibook`. In general, these commits replace custom code with methods from `scrbook`.

En detail:
- Papers in edited volumes are now created using `\chapter`.
- The `\title` command in edited volumes and in the `paper` mode now has two optional arguments, `\title[opt1]{...}[opt2]`. `opt1` goes to the running title, and `opt2` is send to the ToC.
- It is now possible to have mark-up commands like `\textit` or `\textsc` (etc.) in the scope of `\title`, i.e. `\markuptitle` is now discontinued.
- Author(s), their affiliation and the abstract now is printed as part of the `\chapter` block. The text immediately following `\maketitle` is no longer indented and there is a better page break protection immediately after it.
- Improved the appearance of `\includepaper` if it is called between `\frontmatter` and `\mainmatter`. Its title is automatically indented in the ToC, and the chapter number is not printed in the running head. This automates `\lsCollectionPaperFrontmatterMode` so this switch is now discontinued.
- Some load order changes so that all of this works.
- `\fullciteFooter` is moved to the cite style in `langsci-unified.cbx`
- `\lsPaper` is renamed to `\includepaper@body` to make more transparent the fact that `\includepaper@body` is a macro to be called by other macros, not by the user.