### PR TITLE
Fix option passing for biblatex

### DIFF
--- a/langscibook.cls
+++ b/langscibook.cls
@@ -311,7 +311,7 @@
 
 
 \PassOptionsToClass{
-	fontsize=\lsFontsize,% default is 11pt
+    fontsize=\lsFontsize,% default is 11pt
     footnotes=multiple,
     numbers=noenddot,% no point after last number of chapters/sections
     index=totoc,
@@ -320,7 +320,7 @@
 }{scrbook}
 
 \notbool{collection}{
-	\PassOptionsToClass{toc=bib}{scrbook} % make bibliography appear in toc
+    \PassOptionsToClass{toc=bib}{scrbook} % make bibliography appear in toc
 }{}
 
 

--- a/langscibook.cls
+++ b/langscibook.cls
@@ -310,17 +310,21 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-\LoadClass[
-    fontsize=\lsFontsize,% default is 11pt
+\PassOptionsToClass{
+	fontsize=\lsFontsize,% default is 11pt
     footnotes=multiple,
     numbers=noenddot,% no point after last number of chapters/sections
-    \notbool{collection}{
-      toc=bib, % make bibliography appear in toc
-    }{}
     index=totoc,
     headings=optiontohead,
     footnotes=multiple
-    ]{scrbook}
+}{scrbook}
+
+\notbool{collection}{
+	\PassOptionsToClass{toc=bib}{scrbook} % make bibliography appear in toc
+}{}
+
+
+\LoadClass{scrbook}
 
 \ifbool{collection}
   {% In collected volumes, write "Chapter n" instead of "n" in the header


### PR DESCRIPTION
The current release throws an error because the `toc=bib` option is passed to biblatex. you can easily fix that by using `\PassOptionsToClass` instead. Error description at https://fediscience.org/@tschfflr/109703486994618148